### PR TITLE
SAF-28: Error registering plugin flutter_web_view

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/flutterwebview/FlutterWebViewPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/flutterwebview/FlutterWebViewPlugin.kt
@@ -27,8 +27,16 @@ class FlutterWebViewPlugin(val activity: Activity) : MethodCallHandler {
 
         @JvmStatic
         fun registerWith(registrar: Registrar): Unit {
+            val activity = registrar.activity()
+
+            if (activity == null) {
+                // When a background flutter view tries to register the plugin, the registrar has no activity.
+                // We stop the registration process as this plugin is foreground only.
+                return
+            }
+
             channel = MethodChannel(registrar.messenger(), "plugins.apptreesoftware.com/web_view")
-            val plugin = FlutterWebViewPlugin(registrar.activity())
+            val plugin = FlutterWebViewPlugin(activity)
             channel.setMethodCallHandler(plugin)
             redirects.clear()
         }


### PR DESCRIPTION
The error is

```
E/GeneratedPluginRegistrant(18075): Error registering plugin flutter_web_view, com.apptreesoftware.flutterwebview.FlutterWebViewPlugin
E/GeneratedPluginRegistrant(18075): java.lang.IllegalStateException: registrar.activity() must not be null
```
A plugin method channel can be called without activity when we use firebaseMessagingBackgroundHandler. Hence not registering a plugin when activity is null is the workaround.